### PR TITLE
Reverted Wine build to use less of host FS -- was too slow on macOS

### DIFF
--- a/contrib/build-wine/_build.sh
+++ b/contrib/build-wine/_build.sh
@@ -142,7 +142,7 @@ prepare_wine() {
         PYINSTALLER_COMMIT=d1cdd726d6a9edc70150d5302453fb90fdd09bf2
 
         ## These settings probably don't need change
-        export WINEPREFIX=/opt/wine64
+        export WINEPREFIX=$HOME/wine64
         #export WINEARCH='win32'
         export WINEDEBUG=-all
 
@@ -157,11 +157,11 @@ prepare_wine() {
         wine 'wineboot'
 
         info "Cleaning tmp"
-        rm -rf tmp
-        mkdir -p tmp
+        rm -rf $HOME/tmp
+        mkdir -p $HOME/tmp
         info "done"
 
-        cd tmp
+        pushd $HOME/tmp
 
         # note: you might need "sudo apt-get install dirmngr" for the following
         # if the verification fails you might need to get more keys from python.org
@@ -179,7 +179,7 @@ prepare_wine() {
             wget "https://www.python.org/ftp/python/$PYTHON_VERSION/win32/${msifile}.msi"
             wget "https://www.python.org/ftp/python/$PYTHON_VERSION/win32/${msifile}.msi.asc"
             verify_signature "${msifile}.msi.asc" $KEYRING_PYTHON_DEV
-            wine msiexec /i "${msifile}.msi" /qb TARGETDIR=C:/python$PYTHON_VERSION || fail "Failed to install Python component: ${msifile}"
+            wine msiexec /i "${msifile}.msi" /qn TARGETDIR=$PYHOME || fail "Failed to install Python component: ${msifile}"
         done
 
         info "Upgrading pip ..."
@@ -223,7 +223,7 @@ prepare_wine() {
         wine "C:/python$PYTHON_VERSION/scripts/pyinstaller.exe" -v || fail "Pyinstaller installed but cannot be run."
 
         info "Installing Packages from requirements-binaries ..."
-        $PYTHON -m pip install --no-warn-script-location -r ../../deterministic-build/requirements-binaries.txt || fail "Failed to install requirements-binaries"
+        $PYTHON -m pip install --no-warn-script-location -r $here/../deterministic-build/requirements-binaries.txt || fail "Failed to install requirements-binaries"
 
         info "Installing NSIS ..."
         # Install NSIS installer
@@ -243,19 +243,13 @@ prepare_wine() {
         cp "$here"/../secp256k1/libsecp256k1.dll $WINEPREFIX/drive_c/tmp/ || fail "Could not copy libsecp to its destination"
         cp "$here"/../zbar/libzbar-0.dll $WINEPREFIX/drive_c/tmp/ || fail "Could not copy libzbar to its destination"
 
-        popd
+        popd  # out of homedir/tmp
+        popd  # out of $here
 
     ) || fail "Could not prepare Wine"
     info "Wine is configured."
 }
 prepare_wine
-
-info "Resetting modification time in C:\Python..."
-# (Because of some bugs in pyinstaller)
-pushd /opt/wine64/drive_c/python*
-find -exec touch -d '2000-11-11T11:11:11+00:00' {} +
-popd
-ls -l /opt/wine64/drive_c/python*
 
 build_the_app() {
     info "Building $PACKAGE ..."
@@ -267,7 +261,7 @@ build_the_app() {
 
         NAME_ROOT=$PACKAGE  # PACKAGE comes from ../base.sh
         # These settings probably don't need any change
-        export WINEPREFIX=/opt/wine64
+        export WINEPREFIX=$HOME/wine64
         export WINEDEBUG=-all
         export PYTHONDONTWRITEBYTECODE=1
 
@@ -292,7 +286,6 @@ build_the_app() {
         find -exec touch -d '2000-11-11T11:11:11+00:00' {} +
         popd  # go back to $here
 
-        cp "$here"/../../LICENCE "$here"/tmp
         cp -r "$here"/../electrum-locale/locale $WINEPREFIX/drive_c/electroncash/lib/
 
         # Install frozen dependencies
@@ -305,6 +298,13 @@ build_the_app() {
         popd
 
         rm -rf dist/
+
+        info "Resetting modification time in C:\Python..."
+        # (Because we just installed a bunch of stuff)
+        pushd $HOME/wine64/drive_c/python$PYTHON_VERSION
+        find -exec touch -d '2000-11-11T11:11:11+00:00' {} +
+        ls -l
+        popd
 
         # build standalone and portable versions
         info "Running Pyinstaller to build standalone and portable .exe versions ..."

--- a/contrib/build-wine/docker/Dockerfile
+++ b/contrib/build-wine/docker/Dockerfile
@@ -1,6 +1,8 @@
 FROM ubuntu:18.04@sha256:5f4bdc3467537cbbe563e80db2c3ec95d548a9145d64453b06939c4592d67b6d
 
 ENV LC_ALL=C.UTF-8 LANG=C.UTF-8
+ARG USER_ID
+ARG GROUP_ID
 
 RUN dpkg --add-architecture i386 && \
     apt-get update -q && \
@@ -41,3 +43,5 @@ RUN wget -nc https://dl.winehq.org/wine-builds/Release.key && \
 RUN rm -rf /var/lib/apt/lists/* && \
     apt-get autoremove -y && \
     apt-get clean
+
+RUN mkdir -p /homedir/wine64/drive_c/electroncash ; chown -R ${USER_ID}:${GROUP_ID} /homedir && ls -al /homedir


### PR DESCRIPTION
Added a /homedir in the docker image which is owned by UID:GID of
current user.

WINEPREFIX gets put in /homedir/wine64
Electron Cash dir (mounted to hostfs) get put in
/homedir/wine64/drive_c/electroncash

The Dockerfile makes sure to first create these directories and set
their ownership to UID:GID.

More of the guest FS is now being used than in the build_detect_tty
branch and even more is used than on current master (tmp is now on guest
FS).

The build is fast again on macOS.