### PR TITLE
Fixups to get it to build and include the Tor binary for OSX

### DIFF
--- a/contrib/deterministic-build/requirements.txt
+++ b/contrib/deterministic-build/requirements.txt
@@ -67,3 +67,5 @@ wheel==0.33.4 \
 colorama==0.4.1 \
     --hash=sha256:05eed71e2e327246ad6b38c540c4a3117230b19679b875190486ddd2d721422d \
     --hash=sha256:f8ac84de7840f5b9c4e3347b3c1eaa50f7e49c2b07596221daec5edaabbd7c48
+stem==1.8.0 \
+    --hash=sha256:a0b48ea6224e95f22aa34c0bc3415f0eb4667ddeae3dfb5e32a6920c185568c2

--- a/contrib/osx/make_osx
+++ b/contrib/osx/make_osx
@@ -179,9 +179,13 @@ git clean -f -x -q
     --disable-static \
     --enable-shared || fail "Could not configure for secp256k1"
 make -j4 || fail "Could not build secp256k1"
-git checkout master  # Undo the previous explicit checkout to this hash
+#git checkout master  # Undo the previous explicit checkout to this hash
 popd
 cp -fp contrib/secp256k1/.libs/libsecp256k1.0.dylib contrib/osx || fail "Could not copy secp256k1 binary to its destination"
+
+info "Building integrated Tor"
+contrib/make_zlib && contrib/make_libevent && contrib/make_openssl && contrib/make_tor || fail "Could not build Tor"
+
 
 info "Installing requirements..."
 python3 -m pip install -Ir ./contrib/deterministic-build/requirements.txt --user || fail "Could not install requirements"

--- a/contrib/osx/osx.spec
+++ b/contrib/osx/osx.spec
@@ -47,6 +47,8 @@ binaries = [(home + "contrib/osx/libusb-1.0.dylib", ".")]
 binaries += [(home + "contrib/osx/libsecp256k1.0.dylib", ".")]
 # LibZBar for QR code scanning
 binaries += [(home + "contrib/osx/libzbar.0.dylib", ".")]
+# Add Tor binary
+binaries += [(home + "lib/tor/bin/tor", ".")]
 
 # Workaround for "Retro Look":
 binaries += [b for b in collect_dynamic_libs('PyQt5') if 'macstyle' in b[0]]
@@ -62,6 +64,7 @@ a = Analysis([home+MAIN_SCRIPT,
               home+'lib/bitcoin.py',
               home+'lib/dnssec.py',
               home+'lib/commands.py',
+              home+'lib/tor/controller.py',
               home+'plugins/cosigner_pool/qt.py',
               home+'plugins/email_requests/qt.py',
               home+'plugins/trezor/clientbase.py',


### PR DESCRIPTION
Also includes a hashin for the `stem==1.8.0` package in `deterministic/requirements.txt` (1 hash for all platforms since it's platform-neutral).
