### PR TITLE
Fix issue with zxing not able to use images with padding

### DIFF
--- a/electroncash/qrreaders/zxing.py
+++ b/electroncash/qrreaders/zxing.py
@@ -57,10 +57,10 @@ class ZxingCppQrCodeReader(AbstractQrCodeReader):
         self,
         buffer: ctypes.c_void_p,
         buffer_size: int,
-        _rowlen_bytes: int,
+        rowlen_bytes: int,
         width: int,
         height: int,
-        _frame_id: int = -1,
+        frame_id: int = -1,
     ) -> List[QrCodeResult]:
         pybuffer = _PyMemoryView_FromMemory(buffer, buffer_size, _PyBUF_READ).cast("B", (height, width))
 


### PR DESCRIPTION
We flatten the image to ensure each line is width() bytes. We do this in a simple way by just copying each line over without padding to a new buffer in the case where the image has padding.

Let me know if this approach works for you. Tested with both a non-padded and padded image. Attaching 2 images to test. first image is padded and second is not.

![qrcode](https://github.com/EchterAgo/Electron-Cash/assets/266627/a8e5b1a7-af95-478e-9f0d-f035f5c2b3c8)
![qrcode2](https://github.com/EchterAgo/Electron-Cash/assets/266627/d7b0f713-6298-4c0e-9faf-2ee0b505d668)
